### PR TITLE
Allows you to use the "role system" on the LLM server

### DIFF
--- a/vendor/github.com/ManyakRus/starter/chatgpt_connect/chatgpt_connect.go
+++ b/vendor/github.com/ManyakRus/starter/chatgpt_connect/chatgpt_connect.go
@@ -196,7 +196,8 @@ func SendMessage(Text string, user string) (string, error) {
 	Messages := []gogpt.ChatCompletionMessage{
 		{
 			Content: Text,
-			Role:    openai.ChatMessageRoleSystem,
+			Role:    openai.ChatMessageRoleUser,			
+//			Role:    openai.ChatMessageRoleSystem,
 		},
 	}
 


### PR DESCRIPTION
Allows you to use the "role system" on the LLM server.
  { "role": "system", "content": "Always answer in rhymes." },
![image](https://github.com/user-attachments/assets/453ad6b5-ead0-416c-a7f5-e3971eee3da8)

